### PR TITLE
Exposição automática de métricas AMQP

### DIFF
--- a/asyncworker/metrics/definitions/amqp.py
+++ b/asyncworker/metrics/definitions/amqp.py
@@ -1,9 +1,9 @@
 from asyncworker.conf import settings
 from asyncworker.metrics.types import Counter, Histogram, Gauge
 
-# active_consumers = Gauge(
-#    name="amqp_active_consumers", documentation="Count of active consumers"
-# )
+active_consumers = Gauge(
+    name="amqp_active_consumers", documentation="Count of active consumers"
+)
 #
 # processed_messages = Counter(
 #    name="amqp_processed_messages",
@@ -23,7 +23,8 @@ from asyncworker.metrics.types import Counter, Histogram, Gauge
 #
 # flushed_buckets = Counter(
 #    name="amqp_flushed_buckets",
-#    documentation="Count of total AMQP buckets flushed due to ",
+#     labelnames=["reason"],
+#    documentation="Count of total AMQP buckets flushed due to size/timeout",
 # )
 #
 # bucket_handle_duration = Histogram(

--- a/asyncworker/signals/handlers/rabbitmq.py
+++ b/asyncworker/signals/handlers/rabbitmq.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from asyncworker.connections import AMQPConnection
 from asyncworker.consumer import Consumer
+from asyncworker.metrics.definitions.amqp import active_consumers
 from asyncworker.options import RouteTypes
 from asyncworker.signals.handlers.base import SignalHandler
 
@@ -23,5 +24,6 @@ class RabbitMQ(SignalHandler):
                 prefetch_count=conn.prefetch,
             )
             app[RouteTypes.AMQP_RABBITMQ]["consumers"].append(consumer)
+            active_consumers.inc()
             conn.register(consumer.queue)
             app.loop.create_task(consumer.start())

--- a/tests/rabbitmq/test_exposed_metrics.py
+++ b/tests/rabbitmq/test_exposed_metrics.py
@@ -1,0 +1,80 @@
+from asynctest import TestCase, mock, CoroutineMock
+
+from asyncworker import App, RouteTypes
+from asyncworker.connections import AMQPConnection
+from asyncworker.metrics.definitions.amqp import active_consumers
+
+
+class AMQPExposedMetricsTest(TestCase):
+    async def setUp(self):
+        conn = AMQPConnection(
+            hostname="127.0.0.1", username="guest", password="guest"
+        )
+        self.app = App(connections=[conn])
+
+        active_consumers._metric_init()
+
+    async def tearDown(self):
+        await self.app.shutdown()
+
+    async def test_consumer_count_1_consumer_1_route(self):
+        @self.app.route(["queue-1"], RouteTypes.AMQP_RABBITMQ)
+        async def _h(msgs):
+            pass
+
+        with mock.patch("asyncworker.consumer.Consumer.start", CoroutineMock()):
+            samples = active_consumers.collect()[0].samples
+            self.assertEqual(1, len(samples))
+            self.assertEqual(0.0, samples[0].value)
+
+            await self.app.startup()
+
+            samples_after = active_consumers.collect()[0].samples
+            self.assertEqual(1, len(samples_after))
+            self.assertEqual(1.0, samples_after[0].value)
+
+    async def test_active_consumers_1_consumer_2_route_paths(self):
+        """
+        Atualmente ligamos um consumer por @app.route(). Um mesmo consumer consegue
+        ler de múltiplas filas (em um mesmo broker)
+        """
+
+        @self.app.route(["queue-1", "queue-2"], RouteTypes.AMQP_RABBITMQ)
+        async def _h(msgs):
+            pass
+
+        with mock.patch("asyncworker.consumer.Consumer.start", CoroutineMock()):
+            samples = active_consumers.collect()[0].samples
+            self.assertEqual(1, len(samples))
+            self.assertEqual(0.0, samples[0].value)
+
+            await self.app.startup()
+
+            samples_after = active_consumers.collect()[0].samples
+            self.assertEqual(1, len(samples_after))
+            self.assertEqual(1.0, samples_after[0].value)
+
+    async def test_active_consumers_2_consumer_multiple_route_paths(self):
+        """
+        Atualmente ligamos um consumer por @app.route(). Um mesmo consumer consegue
+        ler de múltiplas filas (em um mesmo broker)
+        """
+
+        @self.app.route(["queue-1", "queue-2"], RouteTypes.AMQP_RABBITMQ)
+        async def _h_1(msgs):
+            pass
+
+        @self.app.route(["queue-3", "queue-4"], RouteTypes.AMQP_RABBITMQ)
+        async def _h_2(msgs):
+            pass
+
+        with mock.patch("asyncworker.consumer.Consumer.start", CoroutineMock()):
+            samples = active_consumers.collect()[0].samples
+            self.assertEqual(1, len(samples))
+            self.assertEqual(0.0, samples[0].value)
+
+            await self.app.startup()
+
+            samples_after = active_consumers.collect()[0].samples
+            self.assertEqual(1, len(samples_after))
+            self.assertEqual(2.0, samples_after[0].value)


### PR DESCRIPTION
Implementação da exposição de métricas AMQP.

## Métricas

- [ ] active_consumers (`Gauge`) 
    Está por enquanto errado pois está contando apenas quantos objetos `asyncworker.consumer.Consumer` estão rodando mas um mesmo consumer pode consumir de múltiplas filas. Penso que deveríamos contar os consumers **de fila**.
- [ ] processed_messages  `Counter, labelnames=("queue_name", "action")`
- [ ] active_connections = `Gauge` (depende, de certa forma, do #217)
- [ ] filled_buckets = `Counter`
- [ ] flushed_buckets = `Counter, labelnames=["reason"]`. Aqui `reason` pode ser: `TIMEOUT` ou `SIZE`
- [ ] bucket_handle_duration = `Histogram,     buckets=settings.METRICS_DEFAULT_HISTOGRAM_BUCKETS_IN_MS`
- [ ] Quantidade de falhas de conexão ao broker. Um `Counter` com o número de retries. Usar um label `host`, para que apps com múltiplas conexões com brokers possam ter métricas sepparadas.
