### PR TITLE
Trata todos os DeprecationWarning como erros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,6 @@ supervisord.conf
 
 *.pid
 
-# vamos manter isso fora do git para que cada um possa ter suas preferências locais
-pytest.ini
-
 # Criado automaticamente no browser.quit() ¬¬
 ghostdriver.log
 #cef

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+filterwarnings =
+    error::DeprecationWarning
+    ignore::DeprecationWarning:asyncio[.*]
+    ignore::DeprecationWarning:aiologger[.*]
+    ignore:"@coroutine"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -60,7 +60,10 @@ class AppTests(asynctest.TestCase):
         self.app.update(pet="dog", name="Xablau")
 
         state = dict(**self.app)
-        self.assertDictContainsSubset({"pet": "dog", "name": "Xablau"}, state)
+        self.assertEqual(
+            {"pet": "dog", "name": "Xablau"},
+            {"pet": state["pet"], "name": state["name"]},
+        )
 
     async def test_startup_freezes_applications_and_sends_the_on_startup_signal(
         self,

--- a/tests/types/test_registry.py
+++ b/tests/types/test_registry.py
@@ -80,7 +80,7 @@ class TypesRegistryTest(TestCase):
 
         v: MyGenericDoisArgs[int, str] = MyGenericDoisArgs(10)
         self.registry.set(v, MyGenericDoisArgs[int, str])
-        self.assertEquals(v, self.registry.get(MyGenericDoisArgs[int, str]))
+        self.assertEqual(v, self.registry.get(MyGenericDoisArgs[int, str]))
 
     async def test_generico_dois_args_ordem_importa(self):
         P = TypeVar("P")
@@ -103,7 +103,7 @@ class TypesRegistryTest(TestCase):
 
         v: MyGeneric[OtherObject] = MyGeneric(OtherObject())
         self.registry.set(v, MyGeneric[OtherObject])
-        self.assertEquals(v, self.registry.get(MyGeneric[OtherObject]))
+        self.assertEqual(v, self.registry.get(MyGeneric[OtherObject]))
 
     async def test_generico_um_arg_get_by_name(self):
         class MyGeneric(Generic[T]):


### PR DESCRIPTION
Dessa forma, poderemos manter o código sempre atualizado em relação a depreciações.

Um ponto importante é que não consegui fazer a config apenas para o module `tests`. Por alguma razão que não descobri qual é, a config `error::DeprecationWarning:tests[.*]`, que deveria funcionar, não funcionou,

Então ignorei especificamente os warnings que estavam aparecendo (aiologger, asyncio e o uso de `@coroutine`). Caso apareçam mais warnings de dependências teremos que addicionar o `ignore:` no `pytest.ini`.

Com essa config (e antes das correções) tínhamos 3 casos de warning e que se transformaram em erro.

![screenshot-1621120210](https://user-images.githubusercontent.com/121638/118380889-e3c85180-b5bb-11eb-93d1-59006292de73.jpg)
