### PR TITLE
WIP: Removendo pytest.ini

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -35,7 +35,7 @@ jobs:
         run: pipenv install --system --deploy --ignore-pipfile --dev
 
       - name: pipenv run test
-        run: pipenv run all-tests
+        run: pipenv run test
 
       - name: Coverage upload
         if: ${{matrix.python == '3.8'}}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -35,7 +35,7 @@ jobs:
         run: pipenv install --system --deploy --ignore-pipfile --dev
 
       - name: pipenv run test
-        run: pipenv run test
+        run: pipenv run all-tests
 
       - name: Coverage upload
         if: ${{matrix.python == '3.8'}}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
-[pytest]
-filterwarnings =
-    error::DeprecationWarning
-    ignore::DeprecationWarning:asyncio[.*]
-    ignore::DeprecationWarning:aiologger[.*]
-    ignore:"@coroutine"
+#[pytest]
+#filterwarnings =
+#    error::DeprecationWarning
+#    ignore::DeprecationWarning:asyncio[.*]
+#    ignore::DeprecationWarning:aiologger[.*]
+#    ignore:"@coroutine"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 filterwarnings =
     error::DeprecationWarning
-#    ignore::DeprecationWarning:asyncio[.*]
+    ignore::DeprecationWarning:aioamqp[.*]
+    ignore::DeprecationWarning:asynctest[.*]
     ignore::DeprecationWarning:aiologger[.*]
-    ignore:"@coroutine"
+    ignore::DeprecationWarning:freezegun[.*]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 filterwarnings =
     error::DeprecationWarning
-#    ignore::DeprecationWarning:asyncio[.*]
+    ignore::DeprecationWarning:asyncio[.*]
 #    ignore::DeprecationWarning:aiologger[.*]
 #    ignore:"@coroutine"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 filterwarnings =
     error::DeprecationWarning
     ignore::DeprecationWarning:asyncio[.*]
-#    ignore::DeprecationWarning:aiologger[.*]
+    ignore::DeprecationWarning:aiologger[.*]
 #    ignore:"@coroutine"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 filterwarnings =
     error::DeprecationWarning
-    ignore::DeprecationWarning:asyncio[.*]
+#    ignore::DeprecationWarning:asyncio[.*]
     ignore::DeprecationWarning:aiologger[.*]
-#    ignore:"@coroutine"
+    ignore:"@coroutine"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
-#[pytest]
-#filterwarnings =
-#    error::DeprecationWarning
+[pytest]
+filterwarnings =
+    error::DeprecationWarning
 #    ignore::DeprecationWarning:asyncio[.*]
 #    ignore::DeprecationWarning:aiologger[.*]
 #    ignore:"@coroutine"


### PR DESCRIPTION
Esse PR é uma tentativa de debugar porque o workflow está congelando no PR #15.

- ✅  Removendo completamente o `pytest.ini`: https://github.com/async-worker/async-worker/actions/runs/847262618
- ✅ Voltando apenas a linha que trata todos os warning como erro: https://github.com/async-worker/async-worker/actions/runs/847268183
   - Esse falha, mas essa falha é esperada
- Voltando ao linha `ignore::DeprecationWarning:asyncio[.*]`: https://github.com/async-worker/async-worker/actions/runs/847285261
    - Esse falhou, dizendo que existem muitos DeprecationWarning. Esses warning são do asyncio e deveriam de ter sido igonrados. Talvez essa linha não esteja tendo efeito.
- ✅ Voltando a linha `ignore::DeprecationWarning:aiologger[.*]`: https://github.com/async-worker/async-worker/actions/runs/847302408
    - Já esse run aqui, removeu (corretamente!) os warnings d e uso do `loop` que são gerados no `aiologger`.
- 💣 💥 Tirando o ignore do `asyncio[.*]` e trocando pelo igonre do `"@coroutine"`: https://github.com/async-worker/async-worker/actions/runs/847313098
    - Isso faz o workflow congelar.
- ✅ Trocando o workflow para rodar apenas os testes unitários: https://github.com/async-worker/async-worker/runs/2594611140?check_suite_focus=true
    - Todos os testes passam